### PR TITLE
Setting search paths relative to project path

### DIFF
--- a/utils/librarypath/dproj_itil.go
+++ b/utils/librarypath/dproj_itil.go
@@ -3,6 +3,7 @@ package librarypath
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -77,7 +78,7 @@ func processCompilerOptions(compilerOptions *etree.Element) {
 	}
 	value := otherUnitFiles.SelectAttr("Value")
 	currentPaths := strings.Split(value.Value, ";")
-	currentPaths = GetNewPaths(currentPaths, false)
+	currentPaths = GetNewPaths(currentPaths, false, env.GetCurrentDir())
 	value.Value = strings.Join(currentPaths, ";")
 }
 
@@ -109,7 +110,11 @@ func updateLibraryPathProject(dprojName string) {
 			if child == nil {
 				child = createTagLibraryPath(children)
 			}
-			processCurrentPath(child)
+			rootPath := filepath.Join(env.GetCurrentDir(), path.Dir(dprojName))
+			if _, err := os.Stat(rootPath); os.IsNotExist(err) {
+				rootPath = env.GetCurrentDir()
+			}
+			processCurrentPath(child, rootPath)
 		}
 	}
 
@@ -170,10 +175,10 @@ func isLazarus() bool {
 	return false
 }
 
-func processCurrentPath(node *etree.Element) {
+func processCurrentPath(node *etree.Element, rootPath string) {
 	currentPaths := strings.Split(node.Text(), ";")
 
-	currentPaths = GetNewPaths(currentPaths, false)
+	currentPaths = GetNewPaths(currentPaths, false, rootPath)
 
 	node.SetText(strings.Join(currentPaths, ";"))
 }

--- a/utils/librarypath/global_util_win.go
+++ b/utils/librarypath/global_util_win.go
@@ -50,7 +50,7 @@ func updateGlobalLibraryPath() {
 		}
 
 		splitPaths := strings.Split(paths, ";")
-		newSplitPaths := GetNewPaths(splitPaths, true)
+		newSplitPaths := GetNewPaths(splitPaths, true, env.GetCurrentDir())
 		newPaths := strings.Join(newSplitPaths, ";")
 		err = delphiPlatform.SetStringValue(SearchPathRegistry, newPaths)
 		utils.HandleError(err)

--- a/utils/librarypath/librarypath.go
+++ b/utils/librarypath/librarypath.go
@@ -61,19 +61,19 @@ func GetNewPaths(paths []string, fullPath bool, rootPath string) []string {
 	return paths
 }
 
-func getDefaultPath(fullPath bool) []string {
+func getDefaultPath(fullPath bool, rootPath string) []string {
 	var paths []string
 
 	if !fullPath {
 		fullPath := filepath.Join(env.GetCurrentDir(), consts.FolderDependencies, consts.DcpFolder)
 
-		dir, err := filepath.Rel(env.GetCurrentDir(), fullPath)
+		dir, err := filepath.Rel(rootPath, fullPath)
 		if err == nil {
 			paths = append(paths, dir)
 		}
 
 		fullPath = filepath.Join(env.GetCurrentDir(), consts.FolderDependencies, consts.DcuFolder)
-		dir, err = filepath.Rel(env.GetCurrentDir(), fullPath)
+		dir, err = filepath.Rel(rootPath, fullPath)
 		if err == nil {
 			paths = append(paths, dir)
 		}
@@ -119,7 +119,7 @@ func getNewPathsFromDir(path string, paths []string, fullPath bool, rootPath str
 		return nil
 	})
 
-	for _, path := range getDefaultPath(fullPath) {
+	for _, path := range getDefaultPath(fullPath, rootPath) {
 		if !utils.Contains(paths, path) {
 			paths = append(paths, path)
 		}

--- a/utils/librarypath/librarypath.go
+++ b/utils/librarypath/librarypath.go
@@ -40,7 +40,7 @@ func cleanPath(paths []string, fullPath bool) []string {
 	return processedPaths
 }
 
-func GetNewPaths(paths []string, fullPath bool) []string {
+func GetNewPaths(paths []string, fullPath bool, rootPath string) []string {
 	paths = cleanPath(paths, fullPath)
 	var path = env.GetModulesDir()
 
@@ -52,10 +52,10 @@ func GetNewPaths(paths []string, fullPath bool) []string {
 		if _, err := os.Stat(packagePath); !os.IsNotExist(err) {
 
 			other, _ := models.LoadPackageOther(packagePath)
-			paths = getNewPathsFromDir(filepath.Join(path, value.Name(), other.MainSrc), paths, fullPath)
+			paths = getNewPathsFromDir(filepath.Join(path, value.Name(), other.MainSrc), paths, fullPath, rootPath)
 
 		} else {
-			paths = getNewPathsFromDir(filepath.Join(path, value.Name()), paths, fullPath)
+			paths = getNewPathsFromDir(filepath.Join(path, value.Name()), paths, fullPath, rootPath)
 		}
 	}
 	return paths
@@ -99,7 +99,7 @@ func cleanEmpty(paths []string) []string {
 	return paths
 }
 
-func getNewPathsFromDir(path string, paths []string, fullPath bool) []string {
+func getNewPathsFromDir(path string, paths []string, fullPath bool, rootPath string) []string {
 	_, e := os.Stat(path)
 	if os.IsNotExist(e) {
 		return paths
@@ -110,7 +110,7 @@ func getNewPathsFromDir(path string, paths []string, fullPath bool) []string {
 		if matched {
 			dir, _ := filepath.Split(path)
 			if !fullPath {
-				dir, _ = filepath.Rel(env.GetCurrentDir(), dir)
+				dir, _ = filepath.Rel(rootPath, dir)
 			}
 			if !utils.Contains(paths, dir) {
 				paths = append(paths, dir)


### PR DESCRIPTION
Packages might not be located in the root folder of the repository. We should set paths relative to the project path, instead of the repository root path.

Ex:

```
root 
├── source
│   ├── myfile.pas
├── packages
│   ├── mypackage.dproj
```