### PR TITLE
support default branch "main"

### DIFF
--- a/core/gitWrapper/git.go
+++ b/core/gitWrapper/git.go
@@ -49,13 +49,12 @@ func initSubmodules(dep models.Dependency, repository *git.Repository) {
 
 }
 
-func GetMaster(repository *git.Repository) *config.Branch {
-
-	if branch, err := repository.Branch("master"); err != nil {
-		return nil
-	} else {
-		return branch
+func GetMaster(repository *git.Repository) (*config.Branch, error) {
+	branch, err := repository.Branch("master")
+	if err != nil {
+		branch, err = repository.Branch("main")
 	}
+	return branch, err
 }
 
 func GetVersions(repository *git.Repository) []*plumbing.Reference {

--- a/core/installer/core.go
+++ b/core/installer/core.go
@@ -113,7 +113,7 @@ func ensureModules(rootLock models.PackageLock, pkg *models.Package, deps []mode
 		worktree, _ := repository.Worktree()
 
 		if !hasMatch {
-			if masterReference := gitWrapper.GetMaster(repository); masterReference != nil {
+			if masterReference, err := gitWrapper.GetMaster(repository); err == nil {
 				referenceName = plumbing.NewBranchReferenceName(masterReference.Name)
 			}
 		} else {


### PR DESCRIPTION
Add support for the "main" branch if no dependency version is matched during `boss install`.