### PR TITLE
fix delphi directory retrieval

### DIFF
--- a/utils/dcc32/dcc32.go
+++ b/utils/dcc32/dcc32.go
@@ -16,15 +16,16 @@ func GetDcc32DirByCmd() []string {
 
 	outputStr := strings.ReplaceAll(string(output), "\t", "")
 	outputStr = strings.ReplaceAll(outputStr, "\r", "")
-	outputStr = strings.ReplaceAll(outputStr, "\n", "")
 
-	if len(outputStr) == 0 {
+	if len(strings.ReplaceAll(outputStr, "\n", "")) == 0 {
 		return []string{}
 	}
 
-	installations := strings.Split(outputStr, "\n")
-	for key, value := range installations {
-		installations[key] = filepath.Dir(value)
+	installations := []string{}
+	for _, value := range strings.Split(outputStr, "\n") {
+		if len(strings.TrimSpace(value)) > 0 {
+			installations = append(installations, filepath.Dir(value))
+		}
 	}
 
 	return installations


### PR DESCRIPTION
Fixed `boss config delphi list`

Before:
```
[WARN ] Please restart your console after complete.
[WARN ] Installations found:
[INFO ]   [0] C:\Program Files (x86)\Embarcadero\Studio\21.0\bin\dcc32.exeC:\Program Files (x86)\Embarcadero\RAD Studio\22.0\bin\DCC32.EXE
```

After:
```
[WARN ] Please restart your console after complete.
[WARN ] Installations found:
[INFO ]   [0] C:\Program Files (x86)\Embarcadero\Studio\21.0\bin
[INFO ]   [1] C:\Program Files (x86)\Embarcadero\RAD Studio\22.0\bin
```