### PR TITLE
fix(pkgmanager): prevent nil pointer dereference on malformed boss.json (issues #177, #178)

### DIFF
--- a/utils/librarypath/librarypath.go
+++ b/utils/librarypath/librarypath.go
@@ -75,8 +75,8 @@ func processBrowsingPath(
 ) []string {
 	var packagePath = filepath.Join(basePath, value.Name(), consts.FilePackage)
 	if _, err := os.Stat(packagePath); !os.IsNotExist(err) {
-		other, _ := pkgmanager.LoadPackageOther(packagePath)
-		if other.BrowsingPath != "" {
+		other, err := pkgmanager.LoadPackageOther(packagePath)
+		if err == nil && other != nil && other.BrowsingPath != "" {
 			dir := filepath.Join(basePath, value.Name(), other.BrowsingPath)
 			paths = getNewBrowsingPathsFromDir(dir, paths, fullPath, rootPath)
 			if setReadOnly {
@@ -116,8 +116,12 @@ func GetNewPaths(paths []string, fullPath bool, rootPath string) []string {
 	for _, value := range matches {
 		var packagePath = filepath.Join(path, value.Name(), consts.FilePackage)
 		if _, err := os.Stat(packagePath); !os.IsNotExist(err) {
-			other, _ := pkgmanager.LoadPackageOther(packagePath)
-			paths = getNewPathsFromDir(filepath.Join(path, value.Name(), other.MainSrc), paths, fullPath, rootPath)
+			other, err := pkgmanager.LoadPackageOther(packagePath)
+			if err == nil && other != nil {
+				paths = getNewPathsFromDir(filepath.Join(path, value.Name(), other.MainSrc), paths, fullPath, rootPath)
+			} else {
+				paths = getNewPathsFromDir(filepath.Join(path, value.Name()), paths, fullPath, rootPath)
+			}
 		} else {
 			paths = getNewPathsFromDir(filepath.Join(path, value.Name()), paths, fullPath, rootPath)
 		}


### PR DESCRIPTION
This PR adds safety checks to the package manager to prevent nil pointer dereference panics when loading corrupted or invalid boss.json package descriptors.