### PR TITLE
fix(librarypath): support multiple semicolon-separated paths in mainsrc and browsingpath (issue #143)

### DIFF
--- a/utils/librarypath/librarypath.go
+++ b/utils/librarypath/librarypath.go
@@ -76,11 +76,17 @@ func processBrowsingPath(
 	var packagePath = filepath.Join(basePath, value.Name(), consts.FilePackage)
 	if _, err := os.Stat(packagePath); !os.IsNotExist(err) {
 		other, _ := pkgmanager.LoadPackageOther(packagePath)
-		if other.BrowsingPath != "" {
-			dir := filepath.Join(basePath, value.Name(), other.BrowsingPath)
-			paths = getNewBrowsingPathsFromDir(dir, paths, fullPath, rootPath)
-			if setReadOnly {
-				setReadOnlyProperty(dir)
+		if other != nil && other.BrowsingPath != "" {
+			browsingPaths := strings.Split(other.BrowsingPath, ";")
+			for _, browsingPath := range browsingPaths {
+				browsingPath = strings.TrimSpace(browsingPath)
+				if browsingPath != "" {
+					dir := filepath.Join(basePath, value.Name(), browsingPath)
+					paths = getNewBrowsingPathsFromDir(dir, paths, fullPath, rootPath)
+					if setReadOnly {
+						setReadOnlyProperty(dir)
+					}
+				}
 			}
 		}
 	}
@@ -117,7 +123,19 @@ func GetNewPaths(paths []string, fullPath bool, rootPath string) []string {
 		var packagePath = filepath.Join(path, value.Name(), consts.FilePackage)
 		if _, err := os.Stat(packagePath); !os.IsNotExist(err) {
 			other, _ := pkgmanager.LoadPackageOther(packagePath)
-			paths = getNewPathsFromDir(filepath.Join(path, value.Name(), other.MainSrc), paths, fullPath, rootPath)
+			if other != nil {
+				mainSrcs := strings.Split(other.MainSrc, ";")
+				for _, mainSrc := range mainSrcs {
+					mainSrc = strings.TrimSpace(mainSrc)
+					if mainSrc != "" {
+						paths = getNewPathsFromDir(filepath.Join(path, value.Name(), mainSrc), paths, fullPath, rootPath)
+					} else if len(mainSrcs) == 1 {
+						paths = getNewPathsFromDir(filepath.Join(path, value.Name()), paths, fullPath, rootPath)
+					}
+				}
+			} else {
+				paths = getNewPathsFromDir(filepath.Join(path, value.Name()), paths, fullPath, rootPath)
+			}
 		} else {
 			paths = getNewPathsFromDir(filepath.Join(path, value.Name()), paths, fullPath, rootPath)
 		}

--- a/utils/librarypath/librarypath_test.go
+++ b/utils/librarypath/librarypath_test.go
@@ -69,3 +69,77 @@ func TestGetNewBrowsingPaths(t *testing.T) {
 		t.Error("GetNewBrowsingPaths() should return paths")
 	}
 }
+
+func TestGetNewPaths_MultipleMainSrc(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("BOSS_BASE_DIR", tempDir)
+
+	// Save and restore working directory
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working dir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
+
+	err = os.Chdir(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to change working dir: %v", err)
+	}
+
+	// Create modules directory
+	modulesDir := filepath.Join(tempDir, "modules")
+	libDir := filepath.Join(modulesDir, "my_lib")
+	err = os.MkdirAll(filepath.Join(libDir, "src"), 0755)
+	if err != nil {
+		t.Fatalf("Failed to create src dir: %v", err)
+	}
+	err = os.MkdirAll(filepath.Join(libDir, "lib"), 0755)
+	if err != nil {
+		t.Fatalf("Failed to create lib dir: %v", err)
+	}
+
+	// Create a dummy source file inside both src and lib so they are walked and recognized
+	err = os.WriteFile(filepath.Join(libDir, "src", "my_lib.pas"), []byte("unit my_lib;"), 0600)
+	if err != nil {
+		t.Fatalf("Failed to create dummy file: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(libDir, "lib", "helper.pas"), []byte("unit helper;"), 0600)
+	if err != nil {
+		t.Fatalf("Failed to create dummy file: %v", err)
+	}
+
+	// Create a boss.json with multiple mainsrc paths
+	bossJsonContent := `{
+		"name": "my_lib",
+		"mainsrc": "src;lib"
+	}`
+	err = os.WriteFile(filepath.Join(libDir, "boss.json"), []byte(bossJsonContent), 0600)
+	if err != nil {
+		t.Fatalf("Failed to write boss.json: %v", err)
+	}
+
+	paths := []string{}
+	result := GetNewPaths(paths, true, tempDir)
+
+	// Should contain both src and lib paths
+	foundSrc := false
+	foundLib := false
+	for _, p := range result {
+		if filepath.Base(p) == "src" {
+			foundSrc = true
+		}
+		if filepath.Base(p) == "lib" {
+			foundLib = true
+		}
+	}
+
+	if !foundSrc {
+		t.Error("Expected to find 'src' path in results")
+	}
+	if !foundLib {
+		t.Error("Expected to find 'lib' path in results")
+	}
+}
+


### PR DESCRIPTION
This PR adds support for semicolon-separated multi-paths in the mainsrc and browsingpath variables in package manifests, allowing multi-directory mapping. It includes unit tests.