### PR TITLE
fix(gosec): use 0750 instead of 0755 for MkdirAll (G301)

### DIFF
--- a/internal/adapters/primary/cli/new.go
+++ b/internal/adapters/primary/cli/new.go
@@ -195,12 +195,10 @@ func doCreateProject(name string, pType string, quiet bool) {
 	// Create directories
 	srcDir := filepath.Join(projectDir, "src")
 	testsDir := filepath.Join(projectDir, "tests")
-	//nolint:gosec // Standard directory permissions
-	if err := os.MkdirAll(srcDir, 0755); err != nil {
+	if err := os.MkdirAll(srcDir, 0750); err != nil {
 		msg.Die("❌ Failed to create src directory: %v", err)
 	}
-	//nolint:gosec // Standard directory permissions
-	if err := os.MkdirAll(testsDir, 0755); err != nil {
+	if err := os.MkdirAll(testsDir, 0750); err != nil {
 		msg.Die("❌ Failed to create tests directory: %v", err)
 	}
 


### PR DESCRIPTION
Fixes gosec G301 in Security Scan CI job.

The `//nolint:gosec` directive only works for golangci-lint, not for the standalone gosec (`securego/gosec@master`) used in the Security Scan CI job. Changing `0755` to `0750` satisfies both.