### PR TITLE
fix: restore backward compatibility with v3.0.12 configs and fix the released version string

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,8 +13,9 @@ builds:
       - windows
       - darwin
     ldflags:
-      - github.com/hashload/boss/internal/version.metadata={{.Version}}
-      - github.com/hashload/boss/internal/version.gitCommit={{.Commit}}
+      - -s -w
+      - -X github.com/hashload/boss/internal/version.version={{.Tag}}
+      - -X github.com/hashload/boss/internal/version.gitCommit={{.FullCommit}}
 
 archives:
   - formats: [ tar.gz ]

--- a/pkg/env/configuration.go
+++ b/pkg/env/configuration.go
@@ -46,10 +46,22 @@ type Auth struct {
 	User       string `json:"user,omitempty"`
 	Pass       string `json:"pass,omitempty"`
 	PassPhrase string `json:"keypass,omitempty"`
+
+	// Legacy credentials written by Boss up to v3.0.12, encrypted with the old
+	// AES-CFB scheme. They are kept on the struct so that saving a configuration
+	// that has not been migrated yet round-trips them instead of dropping them.
+	// Migration 7 consumes and clears these fields.
+	LegacyUser       string `json:"x,omitempty"`
+	LegacyPass       string `json:"y,omitempty"`
+	LegacyPassPhrase string `json:"z,omitempty"`
 }
 
 // GetUser returns the decrypted username.
+// An empty value means "not set" and is returned as-is, without decrypting.
 func (a *Auth) GetUser() string {
+	if a.User == "" {
+		return ""
+	}
 	ret, err := crypto.Decrypt(crypto.MachineKey(), a.User)
 	if err != nil {
 		msg.Err("❌ Failed to decrypt user.")
@@ -59,10 +71,14 @@ func (a *Auth) GetUser() string {
 }
 
 // GetPassword returns the decrypted password.
+// An empty value means "not set" and is returned as-is, without decrypting.
 func (a *Auth) GetPassword() string {
+	if a.Pass == "" {
+		return ""
+	}
 	ret, err := crypto.Decrypt(crypto.MachineKey(), a.Pass)
 	if err != nil {
-		msg.Die("❌ Failed to decrypt pass: %s", err)
+		msg.Die("❌ Failed to decrypt pass: %s\n   Run 'boss login' to store the credential again.", err)
 		return ""
 	}
 
@@ -70,10 +86,15 @@ func (a *Auth) GetPassword() string {
 }
 
 // GetPassPhrase returns the decrypted passphrase.
+// An empty value means "the key has no passphrase" and is returned as-is: SSH
+// keys without a passphrase legitimately have nothing stored here.
 func (a *Auth) GetPassPhrase() string {
+	if a.PassPhrase == "" {
+		return ""
+	}
 	ret, err := crypto.Decrypt(crypto.MachineKey(), a.PassPhrase)
 	if err != nil {
-		msg.Die("❌ Failed to decrypt PassPhrase: %s", err)
+		msg.Die("❌ Failed to decrypt PassPhrase: %s\n   Run 'boss login' to store the credential again.", err)
 		return ""
 	}
 	return ret
@@ -120,14 +141,14 @@ func (c *Configuration) GetAuth(repo string) transport.AuthMethod {
 		}
 		var signer ssh.Signer
 
-		if auth.GetPassPhrase() != "" {
-			signer, err = ssh.ParsePrivateKeyWithPassphrase(pem, []byte(auth.GetPassPhrase()))
+		if passPhrase := auth.GetPassPhrase(); passPhrase != "" {
+			signer, err = ssh.ParsePrivateKeyWithPassphrase(pem, []byte(passPhrase))
 		} else {
 			signer, err = ssh.ParsePrivateKey(pem)
 		}
 
 		if err != nil {
-			msg.Die("❌ Failed to parse SSH private key: %v", err)
+			msg.Die("❌ Failed to parse SSH private key: %v\n   Run 'boss login' to store the key and its passphrase again.", err)
 		}
 		return &sshGit.PublicKeys{User: "git", Signer: signer}
 

--- a/pkg/env/legacy_auth_test.go
+++ b/pkg/env/legacy_auth_test.go
@@ -1,0 +1,124 @@
+package env_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashload/boss/pkg/consts"
+	"github.com/hashload/boss/pkg/env"
+	"github.com/hashload/boss/utils/crypto"
+)
+
+// An SSH key without a passphrase stores nothing in keypass. Decrypting that
+// empty value used to fail with "cipher text block size is too short" and, since
+// the getters call msg.Die, took the whole process down — every `boss install`
+// and `boss update` on a machine that had ever run `boss login -s` exited 1.
+func TestAuthGettersTreatEmptyValuesAsUnset(t *testing.T) {
+	auth := &env.Auth{UseSSH: true, Path: "/home/user/.ssh/id_ed25519"}
+
+	if got := auth.GetPassPhrase(); got != "" {
+		t.Errorf("GetPassPhrase() = %q, want %q", got, "")
+	}
+	if got := auth.GetUser(); got != "" {
+		t.Errorf("GetUser() = %q, want %q", got, "")
+	}
+	if got := auth.GetPassword(); got != "" {
+		t.Errorf("GetPassword() = %q, want %q", got, "")
+	}
+}
+
+func TestAuthRoundTripsEncryptedValues(t *testing.T) {
+	auth := &env.Auth{}
+	auth.SetUser("octocat")
+	auth.SetPass("s3cr3t")
+	auth.SetPassPhrase("phrase")
+
+	if got := auth.GetUser(); got != "octocat" {
+		t.Errorf("GetUser() = %q, want %q", got, "octocat")
+	}
+	if got := auth.GetPassword(); got != "s3cr3t" {
+		t.Errorf("GetPassword() = %q, want %q", got, "s3cr3t")
+	}
+	if got := auth.GetPassPhrase(); got != "phrase" {
+		t.Errorf("GetPassPhrase() = %q, want %q", got, "phrase")
+	}
+}
+
+// Configurations written by Boss up to v3.0.12 keep the credentials under
+// x/y/z. Loading and saving one has to round-trip those fields: dropping them
+// destroys the credential before migration 7 ever gets a chance to convert it.
+func TestLegacyAuthFieldsSurviveLoadAndSave(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// LoadConfiguration wipes the auth map when the stored id does not match the
+	// machine, so the fixture has to claim this machine.
+	legacy := map[string]any{
+		"id": crypto.Md5MachineID(),
+		"auth": map[string]any{
+			"github.com": map[string]any{
+				"use":  true,
+				"path": "/home/user/.ssh/id_ed25519",
+				"x":    "bGVnYWN5LXVzZXI=",
+				"y":    "bGVnYWN5LXBhc3M=",
+				"z":    "bGVnYWN5LXBocmFzZQ==",
+			},
+		},
+		"config_version": 6,
+	}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("Failed to marshal legacy config: %v", err)
+	}
+
+	configPath := filepath.Join(tempDir, consts.BossConfigFile)
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	config, err := env.LoadConfiguration(tempDir)
+	if err != nil {
+		t.Fatalf("LoadConfiguration() error = %v", err)
+	}
+
+	auth := config.Auth["github.com"]
+	if auth == nil {
+		t.Fatal("auth entry for github.com is missing")
+	}
+	if auth.LegacyUser != "bGVnYWN5LXVzZXI=" {
+		t.Errorf("LegacyUser = %q, want the value read from x", auth.LegacyUser)
+	}
+	if auth.LegacyPass != "bGVnYWN5LXBhc3M=" {
+		t.Errorf("LegacyPass = %q, want the value read from y", auth.LegacyPass)
+	}
+	if auth.LegacyPassPhrase != "bGVnYWN5LXBocmFzZQ==" {
+		t.Errorf("LegacyPassPhrase = %q, want the value read from z", auth.LegacyPassPhrase)
+	}
+
+	config.SaveConfiguration()
+
+	saved, err := os.ReadFile(configPath) // #nosec G304 -- test-owned temporary path
+	if err != nil {
+		t.Fatalf("Failed to read saved config: %v", err)
+	}
+
+	var reloaded map[string]any
+	if err := json.Unmarshal(saved, &reloaded); err != nil {
+		t.Fatalf("Failed to unmarshal saved config: %v", err)
+	}
+
+	authMap, ok := reloaded["auth"].(map[string]any)
+	if !ok {
+		t.Fatal("saved config has no auth map")
+	}
+	entry, ok := authMap["github.com"].(map[string]any)
+	if !ok {
+		t.Fatal("saved config lost the github.com auth entry")
+	}
+	for _, field := range []string{"x", "y", "z"} {
+		if _, found := entry[field]; !found {
+			t.Errorf("saved config dropped the legacy field %q", field)
+		}
+	}
+}

--- a/setup/migrations.go
+++ b/setup/migrations.go
@@ -4,7 +4,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -46,62 +45,58 @@ func six() {
 	}
 }
 
-// seven migrates the auth configuration
+// seven migrates the auth configuration from the legacy AES-CFB fields
+// (x/y/z, written by Boss up to v3.0.12) to the current ones.
 //
-//nolint:gocognit // Complex migration logic
+// It reads the legacy values off the in-memory configuration rather than
+// re-reading the file: by the time migrations run, the configuration may
+// already have been saved once during startup, and reading from disk would
+// only ever see what the current struct serialises.
+//
+// A credential that cannot be decrypted is dropped with a warning instead of
+// aborting: an undecryptable legacy value is recoverable with `boss login`,
+// while dying here leaves the user with no way to run Boss at all.
 func seven() {
-	bossCfg := filepath.Join(env.GetBossHome(), consts.BossConfigFile)
-	if _, err := os.Stat(bossCfg); os.IsNotExist(err) {
-		return
-	}
-	file, err := os.Open(bossCfg) // #nosec G304 -- Reading Boss configuration file from known location
-	if err != nil {
-		msg.Warn("⚠️ Migration 7: could not open config file: %v", err)
-		return
-	}
-	defer func() { _ = file.Close() }()
+	configuration := env.GlobalConfiguration()
+	migrated := false
 
-	data := map[string]any{}
-
-	if err := json.NewDecoder(file).Decode(&data); err != nil {
-		msg.Warn("⚠️ Migration 7: could not decode config: %v", err)
-		return
-	}
-
-	auth, found := data["auth"].(map[string]any)
-	if !found {
-		return
-	}
-
-	for key, value := range auth {
-		authMap, ok := value.(map[string]any)
-		if !ok {
+	for repo, auth := range configuration.Auth {
+		if auth == nil {
 			continue
 		}
 
-		if user, found := authMap["x"]; found {
-			decryptedUser, err := oldDecrypt(user)
-			if err != nil {
-				msg.Die("❌ Migration 7: critical - failed to decrypt user for %s: %v", key, err)
+		if auth.LegacyUser != "" {
+			if decrypted, err := oldDecrypt(auth.LegacyUser); err != nil {
+				msg.Warn("⚠️ Migration 7: could not migrate the user for %s: %v", repo, err)
+			} else {
+				auth.SetUser(decrypted)
 			}
-			env.GlobalConfiguration().Auth[key].SetUser(decryptedUser)
 		}
 
-		if pass, found := authMap["y"]; found {
-			decryptedPassword, err := oldDecrypt(pass)
-			if err != nil {
-				msg.Die("❌ Migration 7: critical - failed to decrypt password for %s: %v", key, err)
+		if auth.LegacyPass != "" {
+			if decrypted, err := oldDecrypt(auth.LegacyPass); err != nil {
+				msg.Warn("⚠️ Migration 7: could not migrate the password for %s: %v", repo, err)
+			} else {
+				auth.SetPass(decrypted)
 			}
-			env.GlobalConfiguration().Auth[key].SetPass(decryptedPassword)
 		}
 
-		if passPhrase, found := authMap["z"]; found {
-			decryptedPassPhrase, err := oldDecrypt(passPhrase)
-			if err != nil {
-				msg.Die("❌ Migration 7: critical - failed to decrypt passphrase for %s: %v", key, err)
+		if auth.LegacyPassPhrase != "" {
+			if decrypted, err := oldDecrypt(auth.LegacyPassPhrase); err != nil {
+				msg.Warn("⚠️ Migration 7: could not migrate the passphrase for %s: %v", repo, err)
+			} else if decrypted != "" {
+				auth.SetPassPhrase(decrypted)
 			}
-			env.GlobalConfiguration().Auth[key].SetPassPhrase(decryptedPassPhrase)
 		}
+
+		if auth.LegacyUser != "" || auth.LegacyPass != "" || auth.LegacyPassPhrase != "" {
+			auth.LegacyUser, auth.LegacyPass, auth.LegacyPassPhrase = "", "", ""
+			migrated = true
+		}
+	}
+
+	if migrated {
+		configuration.SaveConfiguration()
 	}
 }
 


### PR DESCRIPTION
O Vinicius reportou dois problemas depois do v3.0.13. Fomos atrás, reproduzimos os dois na mão e a correção está aqui, com teste de regressão.

Nenhum dos dois vem do #263 — o `git diff` daquele PR não encosta em `pkg/env/`, `utils/crypto/`, `internal/version/` nem `.goreleaser.yaml`. Os dois estavam dormentes no `main` e apareceram junto porque o v3.0.13 foi o primeiro release tagueado em muito tempo.

---

## 1. `boss install` / `boss update` morrem com `Failed to decrypt PassPhrase`

```
❌ Failed to decrypt PassPhrase: error on check block size: cipher text block size is too short
```

Atinge **qualquer usuário que já tenha rodado `boss login -s` numa versão <= v3.0.12**. E é destrutivo: a credencial some do arquivo, então toda execução seguinte falha igual — não adianta rodar de novo.

### A cadeia

1. Até o v3.0.12 a auth era gravada como `x`/`y`/`z`. O `77196ee` trocou para `user`/`pass`/`keypass` e criou a migração 7 para converter.
2. No startup, `initializeDelphiVersion()` roda **antes** de `migration()` (`setup/setup.go:43` vs `:46`) e chama `SaveConfiguration()` quando `delphi_path` está vazio. Esse save serializa a struct nova — e **apaga o `z` do arquivo**.
3. A migração 7 (`setup/migrations.go:52`) relê o arquivo do disco. O `z` já não está lá, então ela não converte nada e o `keypass` fica vazio.
4. `GetPassPhrase()` chama `Decrypt(key, "")`. Base64 de `""` são 0 bytes, menor que `aes.BlockSize` → o erro acima.
5. O `31e581d` trocou `msg.Err` por `msg.Die` nesses getters, então o que era log virou `exit 1`.

Vale registrar que **nenhum dos dois commits sozinho quebra o usuário**. Com o `77196ee` sozinho, o boss logava o erro e seguia (foi o que medimos rodando o v3.0.12). Com o `31e581d` sozinho, o `keypass` nunca ficaria vazio. A combinação é que fecha o caminho. A ordem `initializeDelphiVersion()` antes de `migration()` é de 2019 e ficou correta por seis anos — só virou armadilha quando o formato mudou.

### Como reproduzimos

Com o `ormbr` e o release oficial v3.0.13 no Windows:

| Cenário | Resultado |
|---|---|
| v3.0.12 `install` | ✅ exit 0 |
| v3.0.13, sem auth configurada | ✅ exit 0 |
| v3.0.13, com auth SSH criada pelo v3.0.12 (`config_version: 6` + `z`, sem `delphi_path`) | ❌ erro acima, exit 1 |
| v3.0.13, 2ª e 3ª execução | ❌ mesmo erro — `z` já foi apagado |

### A correção

- `Auth` passa a carregar os campos legados `x`/`y`/`z`, então salvar uma config ainda não migrada faz round-trip em vez de destruí-los.
- Os getters tratam valor vazio como "não setado" e retornam cedo. Chave SSH sem passphrase legitimamente não guarda nada em `keypass`.
- A migração 7 lê os valores legados da config em memória em vez do arquivo, avisa em vez de morrer quando não consegue decriptar, e salva o que converteu.

Depois do patch, no mesmo ambiente:

| Cenário | Resultado |
|---|---|
| Estado já corrompido (`keypass` vazio, `z` perdido) | ✅ exit 0 |
| Config v3.0.12 legítima (`v6` + `z`, sem `delphi_path`) | ✅ `z` → `keypass` migrado, exit 0 |
| Passphrase real não-vazia | ✅ convertida corretamente |

## 2. `boss -v` reportando `v0.0.1` com o commit em branco

```
Boss CLI Version: v0.0.1
Go Version: go1.26.0
Git Commit:
```

Confirmado baixando o asset oficial do v3.0.13 — não é a máquina de quem reportou.

Os `ldflags` do `.goreleaser.yaml` estão sem o `-X`, então o linker nunca recebe os valores e o binário fica com os defaults de `internal/version`. O `Makefile:32` faz certo; só o GoReleaser, que é quem gera o release, não.

Ficou 17 meses invisível porque o v3.0.13 é o **primeiro release construído pelo GoReleaser** — dá para ver pelo nome dos assets:

| Release | Assets | Origem |
|---|---|---|
| v3.0.12 | `boss-windows-amd64.zip` | Makefile/gox — `-X` correto |
| v3.0.13 | `boss_Windows_x86_64.zip` | GoReleaser — `-X` ausente |

Também trocamos para `version.version` em vez de `version.metadata`: o `metadata` é concatenado ao `version`, então a linha anterior produziria `v0.0.1+3.0.13` mesmo com o `-X` no lugar.

Depois do patch:

```
Boss CLI Version: v3.0.14
Go Version: go1.26.0
Git Commit: ae9d6123a2845972e2370d80da7b9dbec5d9f1b2
```

---

## Testes

`go test ./...` verde nos 29 pacotes. Três testes novos em `pkg/env/legacy_auth_test.go`:

- `TestAuthGettersTreatEmptyValuesAsUnset` — o caso que derrubava o processo
- `TestAuthRoundTripsEncryptedValues` — garante que o early-return não quebrou o caminho normal
- `TestLegacyAuthFieldsSurviveLoadAndSave` — carrega uma config no formato v3.0.12, salva, e verifica que `x`/`y`/`z` continuam no arquivo

## Uma observação sobre processo

A suíte nunca exercita um `~/.boss` legado, então os dois commits passaram no CI e no review sem sinal nenhum. O terceiro teste acima cobre exatamente esse buraco. Se fizer sentido, dá para ampliar num teste de upgrade de ponta a ponta.

## Um achado que deixamos de fora

Com auth SSH configurada para `github.com`, o boss falha todos os pulls com `invalid auth method` e mesmo assim imprime `✅ Installation completed successfully!` com exit 0. O v3.0.12 pelo menos tentava SSH de verdade. Afeta quem usa repositórios privados. Não mexemos aqui para manter o escopo — abrimos issue separada se preferirem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
