### PR TITLE
fix(lint): clear the two findings #268 left on main

### DIFF
--- a/pkg/env/legacy_auth_test.go
+++ b/pkg/env/legacy_auth_test.go
@@ -73,8 +73,8 @@ func TestLegacyAuthFieldsSurviveLoadAndSave(t *testing.T) {
 	}
 
 	configPath := filepath.Join(tempDir, consts.BossConfigFile)
-	if err := os.WriteFile(configPath, data, 0600); err != nil {
-		t.Fatalf("Failed to write config file: %v", err)
+	if writeErr := os.WriteFile(configPath, data, 0600); writeErr != nil {
+		t.Fatalf("Failed to write config file: %v", writeErr)
 	}
 
 	config, err := env.LoadConfiguration(tempDir)

--- a/setup/migrations.go
+++ b/setup/migrations.go
@@ -61,36 +61,7 @@ func seven() {
 	migrated := false
 
 	for repo, auth := range configuration.Auth {
-		if auth == nil {
-			continue
-		}
-
-		if auth.LegacyUser != "" {
-			if decrypted, err := oldDecrypt(auth.LegacyUser); err != nil {
-				msg.Warn("⚠️ Migration 7: could not migrate the user for %s: %v", repo, err)
-			} else {
-				auth.SetUser(decrypted)
-			}
-		}
-
-		if auth.LegacyPass != "" {
-			if decrypted, err := oldDecrypt(auth.LegacyPass); err != nil {
-				msg.Warn("⚠️ Migration 7: could not migrate the password for %s: %v", repo, err)
-			} else {
-				auth.SetPass(decrypted)
-			}
-		}
-
-		if auth.LegacyPassPhrase != "" {
-			if decrypted, err := oldDecrypt(auth.LegacyPassPhrase); err != nil {
-				msg.Warn("⚠️ Migration 7: could not migrate the passphrase for %s: %v", repo, err)
-			} else if decrypted != "" {
-				auth.SetPassPhrase(decrypted)
-			}
-		}
-
-		if auth.LegacyUser != "" || auth.LegacyPass != "" || auth.LegacyPassPhrase != "" {
-			auth.LegacyUser, auth.LegacyPass, auth.LegacyPassPhrase = "", "", ""
+		if migrateLegacyAuth(repo, auth) {
 			migrated = true
 		}
 	}
@@ -98,6 +69,49 @@ func seven() {
 	if migrated {
 		configuration.SaveConfiguration()
 	}
+}
+
+// migrateLegacyAuth converts one entry's legacy credentials and clears them,
+// reporting whether anything was converted.
+func migrateLegacyAuth(repo string, auth *env.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if auth.LegacyUser == "" && auth.LegacyPass == "" && auth.LegacyPassPhrase == "" {
+		return false
+	}
+
+	if decrypted, ok := decryptLegacy(repo, "user", auth.LegacyUser); ok {
+		auth.SetUser(decrypted)
+	}
+	if decrypted, ok := decryptLegacy(repo, "password", auth.LegacyPass); ok {
+		auth.SetPass(decrypted)
+	}
+	// An empty passphrase means the key has none, and storing it back would only
+	// re-create the value migration 7 exists to retire.
+	if decrypted, ok := decryptLegacy(repo, "passphrase", auth.LegacyPassPhrase); ok && decrypted != "" {
+		auth.SetPassPhrase(decrypted)
+	}
+
+	auth.LegacyUser, auth.LegacyPass, auth.LegacyPassPhrase = "", "", ""
+
+	return true
+}
+
+// decryptLegacy decrypts one legacy value, warning instead of aborting when it
+// cannot be read. It reports false when there was nothing to convert.
+func decryptLegacy(repo, field, value string) (string, bool) {
+	if value == "" {
+		return "", false
+	}
+
+	decrypted, err := oldDecrypt(value)
+	if err != nil {
+		msg.Warn("⚠️ Migration 7: could not migrate the %s for %s: %v", field, repo, err)
+		return "", false
+	}
+
+	return decrypted, true
 }
 
 // cleanup cleans up the internal global directory.


### PR DESCRIPTION
O job de Lint já estava vermelho quando o #268 mergeou, em dois achados daquele PR:

```
setup/migrations.go:59: cognitive complexity 25 of func `seven` is high (> 20) (gocognit)
pkg/env/legacy_auth_test.go:76: shadow: declaration of "err" shadows declaration at line 70 (govet)
```

Build, Test e Security Scan passaram — só o Lint ficou.

## O que mudou

`seven` passou do limite porque a reescrita do #268 largou o `//nolint:gocognit` que a versão original carregava. Em vez de recolocar a supressão, o trabalho por entrada foi para `migrateLegacyAuth` e o passo de decriptar-ou-avisar para `decryptLegacy`. Lê melhor que os três blocos quase idênticos que substitui, e derruba a complexidade por conta própria.

No teste, o `err` interno virou `writeErr`.

Sem mudança de comportamento: `go test ./...` segue verde nos 29 pacotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
