### PR TITLE
fix(git): pick the credential for the transport the remote actually uses

### DIFF
--- a/internal/adapters/secondary/git/git.go
+++ b/internal/adapters/secondary/git/git.go
@@ -33,6 +33,23 @@ func UpdateCache(config env.ConfigProvider, dep domain.Dependency) (*goGit.Repos
 	return UpdateCacheNative(dep)
 }
 
+// remoteURL returns the URL the repository actually fetches from.
+//
+// This is not always dep.GetURL(): a cache cloned before an SSH login was
+// configured for the host keeps its original HTTPS remote, and the credential
+// has to be picked for the transport in use, not for the one the manifest
+// would produce today.
+func remoteURL(repository *goGit.Repository, dep domain.Dependency) string {
+	if repository != nil {
+		if remote, err := repository.Remote(goGit.DefaultRemoteName); err == nil {
+			if urls := remote.Config().URLs; len(urls) > 0 {
+				return urls[0]
+			}
+		}
+	}
+	return dep.GetURL()
+}
+
 func initSubmodules(config env.ConfigProvider, dep domain.Dependency, repository *goGit.Repository) error {
 	worktree, err := repository.Worktree()
 	if err != nil {
@@ -46,7 +63,7 @@ func initSubmodules(config env.ConfigProvider, dep domain.Dependency, repository
 	err = submodules.Update(&goGit.SubmoduleUpdateOptions{
 		Init:              true,
 		RecurseSubmodules: goGit.DefaultSubmoduleRecursionDepth,
-		Auth:              config.GetAuth(dep.GetURLPrefix()),
+		Auth:              config.GetAuthForURL(dep.GetURLPrefix(), remoteURL(repository, dep)),
 	})
 	if err != nil {
 		return err
@@ -70,7 +87,7 @@ func GetVersions(config env.ConfigProvider, repository *goGit.Repository, dep do
 	err := repository.Fetch(&goGit.FetchOptions{
 		Force: true,
 		Prune: true,
-		Auth:  config.GetAuth(dep.GetURLPrefix()),
+		Auth:  config.GetAuthForURL(dep.GetURLPrefix(), remoteURL(repository, dep)),
 		RefSpecs: []gitConfig.RefSpec{
 			"refs/*:refs/*",
 			"HEAD:refs/heads/HEAD",

--- a/internal/adapters/secondary/git/git_embedded.go
+++ b/internal/adapters/secondary/git/git_embedded.go
@@ -26,7 +26,7 @@ func CloneCacheEmbedded(config env.ConfigProvider, dep domain.Dependency) (*git.
 	storageCache := makeStorageCache(config, dep)
 	worktreeFileSystem := createWorktreeFs(config, dep)
 	url := dep.GetURL()
-	auth := config.GetAuth(dep.GetURLPrefix())
+	auth := config.GetAuthForURL(dep.GetURLPrefix(), url)
 
 	cloneOpts := &git.CloneOptions{
 		URL:  url,
@@ -73,9 +73,12 @@ func UpdateCacheEmbedded(config env.ConfigProvider, dep domain.Dependency) (*git
 
 	err = repository.Fetch(&git.FetchOptions{
 		Force: true,
-		Auth:  config.GetAuth(dep.GetURLPrefix())})
+		Auth:  config.GetAuthForURL(dep.GetURLPrefix(), remoteURL(repository, dep))})
 	if err != nil && err.Error() != "already up-to-date" {
-		msg.Debug("Error to fetch repository of %s: %s", dep.Repository, err)
+		// The cached copy is still usable, so this is not fatal -- but it is the
+		// difference between "up to date" and "whatever was cached last time",
+		// which the user has to be able to see.
+		msg.Warn("⚠️ Could not update %s, using the cached copy: %s", dep.Repository, err)
 	}
 	if err := initSubmodules(config, dep, repository); err != nil {
 		return nil, err
@@ -133,6 +136,6 @@ func PullEmbedded(config env.ConfigProvider, dep domain.Dependency) error {
 	}
 	return worktree.Pull(&git.PullOptions{
 		Force: true,
-		Auth:  config.GetAuth(dep.GetURLPrefix()),
+		Auth:  config.GetAuthForURL(dep.GetURLPrefix(), remoteURL(repository, dep)),
 	})
 }

--- a/pkg/env/auth_transport_test.go
+++ b/pkg/env/auth_transport_test.go
@@ -1,0 +1,143 @@
+package env_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/hashload/boss/pkg/env"
+	"golang.org/x/crypto/ssh"
+)
+
+// A cache cloned over HTTPS keeps its HTTPS remote even after `boss login -s`
+// configures SSH for the host. Handing the SSH credential to the HTTP transport
+// makes go-git reject the fetch with "invalid auth method", so every dependency
+// of that host silently stops updating.
+func TestGetAuthForURLDropsSSHCredentialOnHTTPRemote(t *testing.T) {
+	config := newConfigWithAuth(t, &env.Auth{UseSSH: true, Path: "/home/user/.ssh/id_ed25519"})
+
+	if got := config.GetAuthForURL("github.com", "https://github.com/hashload/horse"); got != nil {
+		t.Errorf("GetAuthForURL() = %v, want nil for an SSH credential on an HTTPS remote", got)
+	}
+}
+
+func TestGetAuthForURLDropsBasicCredentialOnSSHRemote(t *testing.T) {
+	auth := &env.Auth{}
+	auth.SetUser("octocat")
+	auth.SetPass("s3cr3t")
+	config := newConfigWithAuth(t, auth)
+
+	if got := config.GetAuthForURL("github.com", "git@github.com:hashload/horse"); got != nil {
+		t.Errorf("GetAuthForURL() = %v, want nil for a basic credential on an SSH remote", got)
+	}
+}
+
+func TestGetAuthForURLKeepsMatchingCredential(t *testing.T) {
+	auth := &env.Auth{}
+	auth.SetUser("octocat")
+	auth.SetPass("s3cr3t")
+	config := newConfigWithAuth(t, auth)
+
+	got := config.GetAuthForURL("github.com", "https://github.com/hashload/horse")
+	basic, ok := got.(*http.BasicAuth)
+	if !ok {
+		t.Fatalf("GetAuthForURL() = %T, want *http.BasicAuth", got)
+	}
+	if basic.Username != "octocat" || basic.Password != "s3cr3t" {
+		t.Errorf("GetAuthForURL() returned %q/%q, want octocat/s3cr3t", basic.Username, basic.Password)
+	}
+}
+
+func TestGetAuthForURLWithoutStoredCredential(t *testing.T) {
+	config := newConfigWithAuth(t, nil)
+
+	if got := config.GetAuthForURL("gitlab.com", "https://gitlab.com/group/project"); got != nil {
+		t.Errorf("GetAuthForURL() = %v, want nil when nothing is stored for the host", got)
+	}
+}
+
+// An empty URL means the caller could not determine the transport. Falling back
+// to the stored credential keeps the previous behaviour rather than silently
+// dropping authentication.
+func TestGetAuthForURLFallsBackWhenURLIsUnknown(t *testing.T) {
+	auth := &env.Auth{}
+	auth.SetUser("octocat")
+	auth.SetPass("s3cr3t")
+	config := newConfigWithAuth(t, auth)
+
+	if got := config.GetAuthForURL("github.com", ""); got == nil {
+		t.Error("GetAuthForURL() = nil, want the stored credential when the URL is unknown")
+	}
+}
+
+func TestGetAuthForURLTransportDetection(t *testing.T) {
+	sshAuth := &env.Auth{UseSSH: true, Path: writeTestSSHKey(t)}
+	sshAuth.SetPassPhrase(testKeyPassphrase)
+	config := newConfigWithAuth(t, sshAuth)
+
+	sshRemotes := []string{
+		"git@github.com:hashload/horse",
+		"ssh://git@github.com/hashload/horse",
+		"git@mygitlab.domain.de:delphi/libraries/mylib.git",
+	}
+	for _, remote := range sshRemotes {
+		if got := config.GetAuthForURL("github.com", remote); got == nil {
+			t.Errorf("GetAuthForURL(%q) = nil, want the SSH credential", remote)
+		}
+	}
+
+	httpRemotes := []string{
+		"https://github.com/hashload/horse",
+		"http://github.com/hashload/horse",
+		// A user in an HTTPS URL must not be mistaken for scp-like syntax.
+		"https://octocat@github.com/hashload/horse",
+	}
+	for _, remote := range httpRemotes {
+		if got := config.GetAuthForURL("github.com", remote); got != nil {
+			t.Errorf("GetAuthForURL(%q) = %v, want nil", remote, got)
+		}
+	}
+}
+
+// testKeyPassphrase protects the generated key. Using an encrypted key keeps
+// this test independent of how an empty passphrase is handled.
+const testKeyPassphrase = "test-passphrase"
+
+// writeTestSSHKey writes an encrypted ed25519 key and returns its path.
+// The SSH branch of GetAuth parses the key file, so it needs a real one.
+func writeTestSSHKey(t *testing.T) string {
+	t.Helper()
+
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate the test key: %v", err)
+	}
+
+	block, err := ssh.MarshalPrivateKeyWithPassphrase(private, "", []byte(testKeyPassphrase))
+	if err != nil {
+		t.Fatalf("Failed to marshal the test key: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0600); err != nil {
+		t.Fatalf("Failed to write the test key: %v", err)
+	}
+	return path
+}
+
+func newConfigWithAuth(t *testing.T, auth *env.Auth) *env.Configuration {
+	t.Helper()
+
+	config, err := env.LoadConfiguration(t.TempDir())
+	if config == nil {
+		t.Fatalf("LoadConfiguration() returned no configuration: %v", err)
+	}
+	if auth != nil {
+		config.Auth["github.com"] = auth
+	}
+	return config
+}

--- a/pkg/env/configuration.go
+++ b/pkg/env/configuration.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -127,7 +128,53 @@ func (a *Auth) SetPassPhrase(passphrase string) {
 	}
 }
 
+// usesSSHTransport reports whether rawURL is fetched over SSH.
+func usesSSHTransport(rawURL string) bool {
+	switch {
+	case strings.HasPrefix(rawURL, "ssh://"):
+		return true
+	case strings.HasPrefix(rawURL, "http://"),
+		strings.HasPrefix(rawURL, "https://"),
+		strings.HasPrefix(rawURL, "git://"),
+		strings.HasPrefix(rawURL, "file://"):
+		return false
+	default:
+		// scp-like syntax: [user@]host:path
+		return strings.Contains(rawURL, "@")
+	}
+}
+
+// GetAuthForURL returns the authentication method for a repository, but only
+// when the stored credential fits the transport rawURL will use.
+//
+// The credential is keyed by host, while the transport comes from the URL the
+// repository actually fetches from. Those two disagree whenever a cache was
+// cloned over HTTPS before an SSH login was configured for that host. Handing
+// an SSH credential to the HTTP transport makes go-git fail the fetch with
+// "invalid auth method" -- older versions silently ignored it instead, which is
+// why this only started biting after the go-git upgrade.
+//
+// Returning nil means "fetch anonymously", which is what go-git used to do on
+// its own and is correct for the public repositories this affects. A private
+// repository reached over the wrong transport still fails, as it always did.
+func (c *Configuration) GetAuthForURL(repo, rawURL string) transport.AuthMethod {
+	auth := c.Auth[repo]
+	if auth == nil {
+		return nil
+	}
+
+	if rawURL != "" && auth.UseSSH != usesSSHTransport(rawURL) {
+		msg.Debug("Skipping the credential stored for %s: it does not fit the transport of %s", repo, rawURL)
+		return nil
+	}
+
+	return c.GetAuth(repo)
+}
+
 // GetAuth returns the authentication method for a repository.
+//
+// Prefer GetAuthForURL when the URL being reached is known: this one cannot
+// tell whether the credential fits the transport.
 func (c *Configuration) GetAuth(repo string) transport.AuthMethod {
 	auth := c.Auth[repo]
 

--- a/pkg/env/interfaces.go
+++ b/pkg/env/interfaces.go
@@ -12,6 +12,7 @@ type ConfigProvider interface {
 	GetDelphiPath() string
 	GetGitEmbedded() bool
 	GetAuth(repo string) transport.AuthMethod
+	GetAuthForURL(repo, rawURL string) transport.AuthMethod
 	GetPurgeTime() int
 	GetInternalRefreshRate() int
 	GetLastPurge() time.Time

--- a/pkg/env/legacy_auth_test.go
+++ b/pkg/env/legacy_auth_test.go
@@ -73,8 +73,8 @@ func TestLegacyAuthFieldsSurviveLoadAndSave(t *testing.T) {
 	}
 
 	configPath := filepath.Join(tempDir, consts.BossConfigFile)
-	if err := os.WriteFile(configPath, data, 0600); err != nil {
-		t.Fatalf("Failed to write config file: %v", err)
+	if writeErr := os.WriteFile(configPath, data, 0600); writeErr != nil {
+		t.Fatalf("Failed to write config file: %v", writeErr)
 	}
 
 	config, err := env.LoadConfiguration(tempDir)

--- a/setup/migrations.go
+++ b/setup/migrations.go
@@ -61,36 +61,7 @@ func seven() {
 	migrated := false
 
 	for repo, auth := range configuration.Auth {
-		if auth == nil {
-			continue
-		}
-
-		if auth.LegacyUser != "" {
-			if decrypted, err := oldDecrypt(auth.LegacyUser); err != nil {
-				msg.Warn("⚠️ Migration 7: could not migrate the user for %s: %v", repo, err)
-			} else {
-				auth.SetUser(decrypted)
-			}
-		}
-
-		if auth.LegacyPass != "" {
-			if decrypted, err := oldDecrypt(auth.LegacyPass); err != nil {
-				msg.Warn("⚠️ Migration 7: could not migrate the password for %s: %v", repo, err)
-			} else {
-				auth.SetPass(decrypted)
-			}
-		}
-
-		if auth.LegacyPassPhrase != "" {
-			if decrypted, err := oldDecrypt(auth.LegacyPassPhrase); err != nil {
-				msg.Warn("⚠️ Migration 7: could not migrate the passphrase for %s: %v", repo, err)
-			} else if decrypted != "" {
-				auth.SetPassPhrase(decrypted)
-			}
-		}
-
-		if auth.LegacyUser != "" || auth.LegacyPass != "" || auth.LegacyPassPhrase != "" {
-			auth.LegacyUser, auth.LegacyPass, auth.LegacyPassPhrase = "", "", ""
+		if migrateLegacyAuth(repo, auth) {
 			migrated = true
 		}
 	}
@@ -98,6 +69,49 @@ func seven() {
 	if migrated {
 		configuration.SaveConfiguration()
 	}
+}
+
+// migrateLegacyAuth converts one entry's legacy credentials and clears them,
+// reporting whether anything was converted.
+func migrateLegacyAuth(repo string, auth *env.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if auth.LegacyUser == "" && auth.LegacyPass == "" && auth.LegacyPassPhrase == "" {
+		return false
+	}
+
+	if decrypted, ok := decryptLegacy(repo, "user", auth.LegacyUser); ok {
+		auth.SetUser(decrypted)
+	}
+	if decrypted, ok := decryptLegacy(repo, "password", auth.LegacyPass); ok {
+		auth.SetPass(decrypted)
+	}
+	// An empty passphrase means the key has none, and storing it back would only
+	// re-create the value migration 7 exists to retire.
+	if decrypted, ok := decryptLegacy(repo, "passphrase", auth.LegacyPassPhrase); ok && decrypted != "" {
+		auth.SetPassPhrase(decrypted)
+	}
+
+	auth.LegacyUser, auth.LegacyPass, auth.LegacyPassPhrase = "", "", ""
+
+	return true
+}
+
+// decryptLegacy decrypts one legacy value, warning instead of aborting when it
+// cannot be read. It reports false when there was nothing to convert.
+func decryptLegacy(repo, field, value string) (string, bool) {
+	if value == "" {
+		return "", false
+	}
+
+	decrypted, err := oldDecrypt(value)
+	if err != nil {
+		msg.Warn("⚠️ Migration 7: could not migrate the %s for %s: %v", field, repo, err)
+		return "", false
+	}
+
+	return decrypted, true
 }
 
 // cleanup cleans up the internal global directory.


### PR DESCRIPTION
> **Depende do #269.** Esta branch está empilhada nele para o CI passar, então o diff mostra dois commits. Mergeando o #269 primeiro, este PR reduz sozinho ao commit `fix(git):`.

Validado antes de subir: [PR de validação no fork](https://github.com/isaquepinheiro/boss/pull/13) com os 6 checks verdes, lint incluído.



## O problema

Com qualquer auth SSH cadastrada para um host (`boss login <host> -s`), todo fetch de dependência daquele host falha — e o Boss reporta sucesso mesmo assim:

```
🔁 github_com_hashload_jsonbr    Updating...
⚠️ Fail to fetch repository github.com/hashload/jsonbr: invalid auth method
📦 github_com_hashload_jsonbr    Installed
✅ Installation completed successfully!
```

Exit 0. O projeto fica congelado na versão que já estava em cache, em silêncio. Em CI isso passa verde.

## Causa

A credencial é buscada pelo **prefixo do host**, mas o transporte vem da **URL que o repositório realmente busca**. Os dois discordam sempre que um cache foi clonado por HTTPS antes de uma auth SSH existir para aquele host: `dep.GetURL()` passa a devolver a forma SSH assim que `auth.UseSSH` está setado, enquanto o remote em cache continua HTTPS.

O go-git `v5.4.2` **ignorava** uma credencial SSH entregue ao transporte HTTP e buscava anonimamente. Desde o bump para `v5.19.1` ele devolve `transport.ErrInvalidAuthMethod`. A construção de URL do Boss é idêntica entre v3.0.12 (`models/dep.go:47-56`) e hoje (`internal/core/domain/dependency.go:65-84`) — o que mudou foi a dependência.

## A correção

`Configuration.GetAuthForURL(repo, rawURL)` resolve a credencial contra a URL efetiva e devolve `nil` quando ela não serve ao transporte, restaurando o fetch anônimo que o go-git fazia sozinho. Repositório privado alcançado pelo transporte errado continua falhando, exatamente como antes.

Os cinco call sites passaram a informar a URL real:

- clone → `dep.GetURL()`
- fetch/pull/submódulos → o remote do repositório em cache, via o helper `remoteURL()`

O erro de fetch em `UpdateCacheEmbedded` estava em `msg.Debug` — invisível em verbosidade normal. Virou `msg.Warn` dizendo que a cópia em cache está sendo usada.

## Medição

Mesmo cache, mesma auth SSH, mesmo projeto (`HashLoad/ormbr`), sem `boss-lock.json`, com o cache faltando a tag mais nova do `hashload/cqlbr`. Só troca o binário:

| | sem o fix | com o fix |
|---|---|---|
| `invalid auth method` | 4× | nenhum |
| tags no cache depois | 8 — não buscou | 9 — buscou e restaurou |
| **cqlbr resolvido** | **1.1.6** | **1.1.51** |
| exit code | 0 | 0 |

O `1.1.6` é o dano concreto. Paridade com o v3.0.12 conferida no mesmo snapshot de cache — os quatro módulos resolvem idêntico:

```
cqlbr = 1.1.51   dbcbr = 1.1.7   dbebr = 1.1.7   jsonbr = 1.1.6
```

## Testes

`go test ./...` verde nos 29 pacotes. Seis testes novos em `pkg/env/auth_transport_test.go`:

- credencial SSH em remote HTTPS → descartada
- credencial usuário/senha em remote SSH → descartada
- credencial que casa com o transporte → preservada
- host sem credencial → `nil`
- URL desconhecida → mantém o comportamento anterior, não descarta silenciosamente
- detecção de transporte: `git@host:path`, `ssh://`, `https://`, `http://` e `https://user@host/path`, que não pode ser confundido com sintaxe scp

A chave ed25519 é gerada e cifrada em tempo de execução, então o teste não depende de chave no ambiente.

## Independência

Verificado com `git merge-tree`:

- `fix/auth-transport-mismatch` → `main` : limpo
- `fix/legacy-auth-and-version` → `main` : limpo
- as duas branches entre si : sem conflito

Os dois fixes também foram mesclados localmente para o teste E2E, sem conflito. Podem ser mergeados em qualquer ordem.

## Fora de escopo

Falha de fetch continua **não** alterando o exit code. Endurecer isso muda a política para quem trabalha offline ou atrás de rede instável, e não é o que este bug exige — com o fix, o `invalid auth method` deixa de acontecer. Se quisermos endurecer mesmo, vale discutir separado, porque afeta CI de terceiros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

