### PR TITLE
fix(librarypath): resolve a subdirectory project's paths against its own directory

### DIFF
--- a/utils/librarypath/dproj_util.go
+++ b/utils/librarypath/dproj_util.go
@@ -4,7 +4,6 @@ package librarypath
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -128,6 +127,18 @@ func updateGlobalBrowsingPath(pkg *domain.Package) {
 	}
 }
 
+// dprojRootPath returns the directory a project file's own paths are relative to.
+// dprojName is always an absolute, OS-native path (GetProjectNames builds every entry
+// with filepath.Join), so its parent has to be resolved with filepath.Dir. path.Dir
+// only understands "/": on Windows it finds no separator in a backslash path and
+// answers ".", and on POSIX it answers correctly but the caller then joined that
+// absolute result onto the working directory, doubling the path. Both ways the
+// project's real directory was lost. Kept in this file, rather than inlined, so the
+// Windows-only browsing path caller shares one definition with the .dproj caller.
+func dprojRootPath(dprojName string) string {
+	return filepath.Dir(dprojName)
+}
+
 // updateLibraryPathProject updates the library path in the project file.
 func updateLibraryPathProject(dprojName string) {
 	doc := etree.NewDocument()
@@ -151,11 +162,7 @@ func updateLibraryPathProject(dprojName string) {
 			if child == nil {
 				child = createTagLibraryPath(children)
 			}
-			rootPath := filepath.Join(env.GetCurrentDir(), path.Dir(dprojName))
-			if _, err = os.Stat(rootPath); os.IsNotExist(err) {
-				rootPath = env.GetCurrentDir()
-			}
-			processCurrentPath(child, rootPath)
+			processCurrentPath(child, dprojRootPath(dprojName))
 		}
 	}
 

--- a/utils/librarypath/dproj_util_test.go
+++ b/utils/librarypath/dproj_util_test.go
@@ -1,0 +1,92 @@
+//nolint:testpackage // Testing internal dproj utility functions
+package librarypath
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/beevik/etree"
+	"github.com/hashload/boss/internal/adapters/secondary/filesystem"
+	"github.com/hashload/boss/internal/adapters/secondary/repository"
+	"github.com/hashload/boss/internal/core/services/packages"
+	"github.com/hashload/boss/pkg/pkgmanager"
+)
+
+const mockDprojContent = `<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Base)'!=''">
+    <DCC_UnitSearchPath>$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+  </PropertyGroup>
+</Project>
+`
+
+// TestUpdateLibraryPathProject_SubdirectoryProject verifies that a .dproj located in a
+// subdirectory of the boss.json root gets paths relative to its OWN directory, not to
+// the root. dprojName is always an absolute, OS-native path (built via filepath.Join),
+// so resolving its parent directory must use filepath.Dir rather than path.Dir -- the
+// latter only understands "/" and silently collapses to "." on a Windows backslash path.
+func TestUpdateLibraryPathProject_SubdirectoryProject(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	fs := filesystem.NewOSFileSystem()
+	packageRepo := repository.NewFilePackageRepository(fs)
+	lockRepo := repository.NewFileLockRepository(fs)
+	packageService := packages.NewPackageService(packageRepo, lockRepo)
+	pkgmanager.SetInstance(packageService)
+
+	depSrcDir := filepath.Join(tempDir, "modules", "mydep", "src")
+	if err := os.MkdirAll(depSrcDir, 0755); err != nil {
+		t.Fatalf("Failed to create dependency src dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(depSrcDir, "dummy.pas"), []byte("unit dummy;"), 0600); err != nil {
+		t.Fatalf("Failed to write dummy.pas: %v", err)
+	}
+	depBossJSON := `{"name": "mydep", "mainsrc": "src"}`
+	depBossJSONPath := filepath.Join(tempDir, "modules", "mydep", "boss.json")
+	if err := os.WriteFile(depBossJSONPath, []byte(depBossJSON), 0600); err != nil {
+		t.Fatalf("Failed to write dependency boss.json: %v", err)
+	}
+
+	projectDir := filepath.Join(tempDir, "app")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatalf("Failed to create project dir: %v", err)
+	}
+	dprojPath := filepath.Join(projectDir, "project.dproj")
+	if err := os.WriteFile(dprojPath, []byte(mockDprojContent), 0600); err != nil {
+		t.Fatalf("Failed to write mock dproj: %v", err)
+	}
+
+	updateLibraryPathProject(dprojPath)
+
+	doc := etree.NewDocument()
+	if err := doc.ReadFromFile(dprojPath); err != nil {
+		t.Fatalf("Failed to read updated dproj: %v", err)
+	}
+
+	var searchPath string
+	for _, group := range doc.Root().FindElements("PropertyGroup") {
+		if el := group.SelectElement("DCC_UnitSearchPath"); el != nil {
+			searchPath = el.Text()
+		}
+	}
+	if searchPath == "" {
+		t.Fatal("DCC_UnitSearchPath not found in updated dproj")
+	}
+
+	expected := filepath.Join("..", "modules", "mydep", "src")
+	if !strings.Contains(filepath.Clean(searchPath), expected) {
+		t.Errorf("expected DCC_UnitSearchPath to contain %q (relative to the project's own directory), got %q",
+			expected, searchPath)
+	}
+
+	wrong := filepath.Join("modules", "mydep", "src")
+	for _, entry := range strings.Split(searchPath, ";") {
+		if filepath.Clean(entry) == wrong {
+			t.Errorf("DCC_UnitSearchPath contains %q, which is relative to the boss.json root instead of "+
+				"the project's own directory -- rootPath was computed wrong", entry)
+		}
+	}
+}

--- a/utils/librarypath/global_util_win.go
+++ b/utils/librarypath/global_util_win.go
@@ -5,8 +5,6 @@
 package librarypath
 
 import (
-	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/hashload/boss/pkg/consts"
@@ -103,8 +101,7 @@ func updateGlobalBrowsingByProject(dprojName string, setReadOnly bool) {
 		}
 
 		splitPaths := strings.Split(paths, ";")
-		rootPath := filepath.Join(env.GetCurrentDir(), path.Dir(dprojName))
-		newSplitPaths := GetNewBrowsingPaths(splitPaths, false, rootPath, setReadOnly)
+		newSplitPaths := GetNewBrowsingPaths(splitPaths, false, dprojRootPath(dprojName), setReadOnly)
 		newPaths := strings.Join(newSplitPaths, ";")
 		err = delphiPlatform.SetStringValue(BrowsingPathRegistry, newPaths)
 		if err != nil {


### PR DESCRIPTION
## O problema

Um projeto que não fica ao lado do `boss.json` — um projeto de testes numa subpasta, por exemplo — recebe os paths das dependências relativos à raiz do `boss.json`, e não à pasta dele. O que vai parar no `DCC_UnitSearchPath` aponta para lugar nenhum, e a compilação morre mesmo com o boss reportando instalação bem-sucedida:

```
[dcc32 Fatal Error] ProjectTests.pas(7): F2613 Unit 'SomeDependency' not found.
```

Com o `.dproj` em `<raiz>/tests/` e as dependências em `<raiz>/modules/`, o boss escreve `modules\...`, quando o correto a partir de `tests/` é `..\modules\...`.

Não é o comportamento pretendido: os dois trechos afetados nasceram justamente para resolver o path por projeto — `14b5102 "Setting search paths relative to project path"` e `ac7fe16 "Adding browsing path by project relative root folder"`. Se a ideia fosse fixar tudo na raiz do `boss.json`, bastaria `rootPath := env.GetCurrentDir()`; a presença de `path.Dir(dprojName)` mostra a intenção de usar a pasta do próprio projeto. O suporte a projeto fora da raiz também é explícito em `getExplicitProjectNames`, que aceita caminho absoluto e resolve caminho relativo contra a raiz.

## Causa

```go
rootPath := filepath.Join(env.GetCurrentDir(), path.Dir(dprojName))
if _, err = os.Stat(rootPath); os.IsNotExist(err) {
    rootPath = env.GetCurrentDir()
}
```

`dprojName` é sempre um caminho absoluto e nativo do SO — `GetProjectNames` monta toda entrada com `filepath.Join`. Mas `path.Dir` só entende `/`, então os dois sistemas perdem o diretório do projeto por caminhos diferentes:

- **Windows**: não há `/` num caminho com barra invertida, então `path.Dir` responde `"."`, o `Join` volta para o diretório de trabalho, e a guarda `os.Stat` nunca dispara — porque esse diretório existe de verdade.
- **POSIX**: `path.Dir` responde certo, mas juntar um resultado absoluto sobre o diretório de trabalho duplica o caminho (`/home/user/proj/home/user/proj/tests`). Aí o `os.Stat` falha e a guarda cai no diretório de trabalho.

Os dois terminam na raiz do `boss.json`. Não é específico de plataforma nem de versão do Delphi — é a API de path errada.

## A correção

`filepath.Dir` responde certo nos dois sistemas, então o `rootPath` sai direto dele. Os dois call sites (o `.dproj` e o browsing path do Windows) passam a compartilhar um helper, `dprojRootPath`, que documenta a armadilha num lugar só.

A guarda `os.Stat` foi junto: `updateLibraryPathProject` já faz `os.Stat(dprojName)` e retorna quando o arquivo não existe, e um arquivo que existe sempre tem um pai que existe — o ramo tinha virado inalcançável.

### Quem muda de comportamento

**Projeto na raiz do `boss.json` — o caso comum — não muda em nada**, nos dois sistemas:

| | antes | depois |
|---|---|---|
| raiz, windows | `path.Dir`→`"."`, `Join`→cwd | `filepath.Dir`→cwd |
| raiz, posix | path duplicado → guarda → cwd | `filepath.Dir`→cwd |
| subpasta | cwd (paths quebrados) | pasta do projeto |

Só muda quem já estava quebrado. E nada muda em *quais* projetos são escritos: isso é decidido por `GetProjectNames`, que este PR não toca — a auto-descoberta continua lendo só a raiz, sem recursão, e uma subpasta só é tocada se estiver listada em `projects`.

A profundidade é livre, porque quem calcula o caminho é o `filepath.Rel`: `tests/app.dproj` recebe `..\modules\...`, `a/b/c/app.dproj` recebe `..\..\..\modules\...`.

Vale registrar um caso: se a subpasta for ela mesma um projeto boss, com `boss.json` e `modules/` próprios, o comportamento antigo escrevia `modules\...`, que resolvido a partir da subpasta caía no `modules/` **dela** — acertando por acidente quando as duas tinham uma dependência de mesmo nome. Agora aponta para o `modules/` da raiz, que é o que a raiz pediu ao listar aquele projeto. Quem gerencia o projeto aninhado rodando `boss install` dentro dele não sente diferença: esse é o caso da primeira linha da tabela. Um `boss.json` aninhado segue invisível para a execução da raiz, que varre apenas `<cwd>/modules`.

## Testes

`TestUpdateLibraryPathProject_SubdirectoryProject` monta uma dependência em `modules/mydep/src` e um `.dproj` em `app/`, e cobra o path relativo à pasta do projeto. Verificado como regressão de verdade — revertendo só a linha do fix:

```
--- FAIL: TestUpdateLibraryPathProject_SubdirectoryProject
    expected DCC_UnitSearchPath to contain "..\modules\mydep\src", got
    "$(DCC_UnitSearchPath);modules\mydep\src;modules\.dcp;modules\.dcu"
```

- `go test ./...` verde em todos os pacotes.
- `go build ./...` e `go vet ./...` limpos.
- `golangci-lint`: **nenhum achado novo**. Medido contra o `main` num worktree com LF: 9 achados no `main`, 9 nesta branch, mesmo detalhamento — todos pré-existentes em `global_util_win.go`, que o lint do CI não analisa por causa do build tag.

Validado também de ponta a ponta num projeto real com o `.dproj` de testes numa subpasta: antes do fix o arquivo recebia `modules\...` e o compilador não achava as units; depois recebe `..\modules\...` e todas resolvem. O `.dproj` da raiz do mesmo projeto continuou byte a byte igual, como esperado pela tabela acima. Rodando o install três vezes seguidas o resultado é idêntico — a de-duplicação continua vindo do `utils.Contains`, então não há crescimento da lista.

## Uma ressalva sobre o browsing path

O browsing path é um valor único no registro, e `updateGlobalBrowsingPath` percorre todos os projetos escrevendo nele. Com projetos em profundidades diferentes, o último processado decide a base do caminho relativo — antes todos escreviam relativo à raiz, agora cada um escreve relativo a si. Nenhum valor único serve aos dois casos, então isso é limitação do desenho e não algo introduzido aqui; o que muda é qual projeto acaba favorecido. Para o caso de um projeto só, que é o comum, não há diferença. Se preferirem, dá para restringir o fix ao `.dproj` — onde a semântica é inequívoca, já que o MSBuild resolve caminho relativo contra o próprio arquivo de projeto — e tratar o browsing path à parte.

## Fora de escopo

Dois problemas vizinhos que apareceram na investigação e não entram aqui:

- `cleanPath` monta o prefixo contra `env.GetCurrentDir()`, então num projeto em subpasta ele nunca reconhece os paths que o próprio boss escreveu (`..\modules\...`) e não remove o que sobrou de uma dependência desinstalada. O path fica órfão no `.dproj`, sem quebrar a compilação.
- `processCompilerOptions`, no caminho do Lazarus, usa `env.GetCurrentDir()` fixo e tem a mesma limitação para um `.lpi`/`.lpk` em subpasta. Corrigir exige passar o nome do arquivo adiante, o que muda mais superfície do que este bug pede.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

